### PR TITLE
Feature card targetting

### DIFF
--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -13,7 +13,7 @@ use crate::game_objects::BoardZone;
 pub enum GameEvent {
     Started, // usually passed to new states to run their logic immediately
     CardPicked(usize),
-    CardTargeted(usize),
+    CardTargeted(BoardZone, usize, BoardZone, usize),
     CardBought(BoardZone, usize),
     EndTurn, 
     IO(Event), // keyboard, mouse etc.

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -125,17 +125,6 @@ impl BoardState {
         }
     }
 
-    pub fn evaluate_targeted_effect(&mut self, effect: &TargetEffect, target_container: &mut CardContainer, target_idx: usize) {
-        match effect {
-            TargetEffect::Kill => { target_container.cards.remove(target_idx); },
-            TargetEffect::Bounce => {
-                let target = target_container.cards.remove(target_idx);
-                self.deck.add(target);
-            },
-            _ => ()
-        }
-    }
-
     pub fn store_by_zone(&mut self, zone: BoardZone) -> &mut Store {
         self.stores.iter_mut()
             .find(|s| s.menu.zone == zone)

--- a/src/game_objects.rs
+++ b/src/game_objects.rs
@@ -23,6 +23,8 @@ pub enum Effect {
     Return,
     ToBuildings,
     Break,
+    Kill,
+    Bounce,
     None
 }
 
@@ -99,6 +101,7 @@ pub struct Card {
     pub draw_to: DrawTo,
     pub available: bool,
     pub image: String,
+    pub target: BoardZone
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/src/game_objects.rs
+++ b/src/game_objects.rs
@@ -23,9 +23,20 @@ pub enum Effect {
     Return,
     ToBuildings,
     Break,
+    None,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TargetEffect {
+    None,
     Kill,
     Bounce,
-    None
+}
+
+impl Default for TargetEffect {
+    fn default() -> Self {
+        TargetEffect::None
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,6 +93,12 @@ pub enum BoardZone {
     KaijuStore
 }
 
+impl BoardZone {
+    fn default_draw() -> Self {
+        BoardZone::Hand
+    }
+}
+
 impl Default for BoardZone {
     fn default() -> BoardZone {
         BoardZone::None
@@ -98,10 +115,15 @@ pub struct Card {
     pub on_strike: Vec<Effect>,
     pub on_defend: Vec<Effect>,
     pub cost: Cost,
-    pub draw_to: DrawTo,
-    pub available: bool,
+    pub available: bool,    
+
+    pub target_zone: BoardZone,
+    pub target_effect: TargetEffect,
+
     pub image: String,
-    pub target: BoardZone
+
+    #[serde(default = "BoardZone::default_draw")]
+    pub draw_to: BoardZone,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -141,8 +163,13 @@ impl CardContainer {
         self.cards[idx].clone()
     }
 
-    fn remove(&mut self, card_idx: usize) -> Card {
-        self.cards.remove(card_idx)
+    // Safe remove
+    pub fn remove(&mut self, card_idx: usize) -> Option<Card> {
+        if self.cards.len() > 0 {
+            Some(self.cards.remove(card_idx))
+        } else {
+            None
+        }
     }
 
     /// Extract effects linked to speciffied event for each card in the container (effects can repeat). 
@@ -165,7 +192,6 @@ impl PartialEq for CardContainer {
     }
 }
 impl Eq for CardContainer {}
-
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Deck {

--- a/static/cards.json
+++ b/static/cards.json
@@ -19,9 +19,9 @@
           {"effect": "ToBuildings" }
         ], "cost": {"count": 3, "currency": "Build"}, "image": "kaiju.png"},
 
-      "tank": {"name": "Tanks", "target": "Kaiju", "on_play": [
-          {"effect": "Kill"}
-        ], "cost": {"count": 2, "currency": "Build"}, "image": "kaiju.png"},
+      "tank": {"name": "Tanks",
+              "target_zone": "Kaiju", "target_effect": "Kill",
+              "cost": {"count": 2, "currency": "Build"}, "image": "kaiju.png"},
 
       "kaiju": {"name": "Regular kaiju", "on_strike": [
           {"effect": "Echo", "msg": "I see a bad moon rising" },

--- a/static/cards.json
+++ b/static/cards.json
@@ -19,9 +19,8 @@
           {"effect": "ToBuildings" }
         ], "cost": {"count": 3, "currency": "Build"}, "image": "kaiju.png"},
 
-      "tank": {"name": "Tanks", "on_play": [
-          {"effect": "Echo", "msg": "Boom! Boom!" },
-          {"effect": "Global", "key": "Attack", "val": 1 }
+      "tank": {"name": "Tanks", "target": "Kaiju", "on_play": [
+          {"effect": "Kill"}
         ], "cost": {"count": 2, "currency": "Build"}, "image": "kaiju.png"},
 
       "kaiju": {"name": "Regular kaiju", "on_strike": [


### PR DESCRIPTION
Scaffold for card targetting

- support on game logic side, data structures, json deserialization, etc
- a new state for handling card targetting
  - at the moment it only gives control back to GameplayState
- handling of targeted effects, meaning TANKS CAN FINALLY SHOOT KAIJU
- safe remove from CardContainer, meaning this closes #12 

*NOTE 1*: Forked from origin/refactor_loading, should be merged after #11 
*NOTE 2*: Merge should probably wait until you add the UI part, hence the draft