### PR TITLE
gui refactor - removed widget creation into board_display.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,6 +1897,7 @@ dependencies = [
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quicksilver 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ json = "*"
 itertools = "*"
 derivative = "1.0"
 futures = "= 0.1" # Use the same version as quicksilver (see comments for LoadingState)
+rand = "*"
 
 [dependencies.quicksilver]
 version = "= 0.3.20"

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -239,7 +239,7 @@ impl AutomatonState for GameplayState {
                     annoyance.intercepts_left -= 1;
                     self.board.hand.remove(card_idx);
 
-                    return TakeTurnState::new(Box::new(take(self)))
+                    return self.take_turn()
                 }
 
                 // play the card
@@ -247,9 +247,10 @@ impl AutomatonState for GameplayState {
                 match card_target {
                     BoardZone::None => {
                         self.board.play_card(card_idx);
-                        TakeTurnState::new(Box::new(take(self)))
+                        self.take_turn()
                     },
                     _ => {
+                        self.board.update_availability();
                         TargetingState::new(Box::new(take(self)), BoardZone::Hand, card_idx, card_target)
                     }
                 }
@@ -258,7 +259,7 @@ impl AutomatonState for GameplayState {
                 if target_zone != BoardZone::None {
                     self.board.play_card_on_target(card_idx, target_zone, target_idx);
                 };
-                TakeTurnState::new(Box::new(take(self)))
+                self.take_turn()
             },
 
             GameEvent::CardBought(zone, card_idx) => {

--- a/src/game_objects.rs
+++ b/src/game_objects.rs
@@ -1,6 +1,8 @@
 extern crate quicksilver;
 extern crate json;
 
+use rand::thread_rng;
+use rand::seq::SliceRandom;
 use quicksilver::prelude::*;
 use std::collections::VecDeque;
 use std::collections::HashMap;
@@ -250,9 +252,11 @@ impl Deck {
         self.cards.push_back(new_card)
     }
 
-    pub fn shuffle(&self) {
-        unimplemented!
-        ()
+    pub fn shuffle(&mut self) {
+        let mut card_pile: Vec<Card> = self.cards.drain(..).collect();
+        card_pile.shuffle(&mut thread_rng());
+        self.cards.clear();
+        self.cards.extend(card_pile);
     }
 }
 

--- a/src/game_objects.rs
+++ b/src/game_objects.rs
@@ -258,6 +258,10 @@ impl Deck {
         self.cards.clear();
         self.cards.extend(card_pile);
     }
+
+    pub fn len(&self) -> usize {
+        self.cards.len()
+    }
 }
 
 impl From<Vec<Card>> for Deck {

--- a/src/game_objects.rs
+++ b/src/game_objects.rs
@@ -185,6 +185,10 @@ impl Deck {
         unimplemented!
         ()
     }
+
+    pub fn len(&self) -> usize {
+        self.cards.len()
+    }
 }
 
 impl From<Vec<Card>> for Deck {

--- a/src/game_objects.rs
+++ b/src/game_objects.rs
@@ -86,7 +86,7 @@ impl Default for Cost {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BoardZone {
     None,
     Hand,

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -2,7 +2,6 @@ extern crate quicksilver;
 extern crate json;
 
 use quicksilver::prelude::*;
-use std::collections::VecDeque;
 use std::collections::HashMap;
 use itertools::Itertools;
 use std::iter;
@@ -234,12 +233,12 @@ impl AutomatonState for LoadingState {
             // We use draining iterators to take ownership
             Ok(Async::Ready((mut fonts, mut images))) => {
                 let mut loaded_fonts = HashMap::new();
-                for (k, v) in self.font_names.drain((..)).zip(fonts.drain((..))) {
+                for (k, v) in self.font_names.drain(..).zip(fonts.drain(..)) {
                     loaded_fonts.insert(k, Box::new(v));
                 }
 
                 let mut loaded_images = HashMap::new();
-                for (k, v) in self.image_names.drain((..)).zip(images.drain((..))) {
+                for (k, v) in self.image_names.drain(..).zip(images.drain(..)) {
                     loaded_images.insert(k, Rc::new(v));
                 }
 

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -72,6 +72,7 @@ fn parse_store(zone: BoardZone, json: &serde_json::value::Value, node: &str, fac
 
         StoreType::Drafted { size, from_deck } => {
             let mut deck = parse_deck(json, &from_deck, factory);
+            deck.shuffle();
 
             let cards = (0..size).filter_map(|_| deck.draw()).collect();
 

--- a/src/ui/board_display.rs
+++ b/src/ui/board_display.rs
@@ -1,0 +1,151 @@
+/// UI states for our game's push-down automaton
+
+use crate::automaton::*;
+use crate::game_logic::*;
+use quicksilver::prelude::*;
+use quicksilver::lifecycle::{Event, Window};
+use serde::export::fmt::Debug;
+use std::collections::HashMap;
+
+use super::widgets::*;
+use crate::game_objects::{BoardZone, Globals}; //, GameData, Card, Effect, };
+
+// pub const WINDOW_SIZE_W: f32 = 1280.0;
+// pub const WINDOW_SIZE_H: f32 = 800.0;
+const PLAYER_BOARD_FROM_TOP: f32 = 300.0;
+const BASE_Z_INDEX: f32 = 1.0; // widgets will be layered starting with this Z
+
+#[derive(Debug)]
+pub struct BoardDisplay {
+    widgets: Vec<Box<dyn Widget>>,
+    window_w: f32,
+    window_h: f32
+}
+
+impl BoardDisplay {
+    pub fn new(gameplay_state: &GameplayState, handlers: HashMap<BoardZone, CardHandler>, window_w: f32, window_h: f32) -> Box<Self> {
+        let assets = gameplay_state.get_assets();
+        let mut widgets = Vec::new();
+
+        // Next turn button
+        widgets.push(Box::new(Button::new(
+            "End\nturn".to_string(),
+            Vector::new(UI_UNIT * 7.0, UI_UNIT * 45.0),
+            BASE_Z_INDEX,
+            &assets,
+            Some(GameEvent::EndTurn),
+        ),
+        ) as Box<dyn Widget>);
+
+        // Hand
+        let hand_zone = CardZone::<CardFull>::from_container(&gameplay_state.get_board().hand,
+                                                             Vector::new(13.0 * UI_UNIT, 35.0 * UI_UNIT),
+                                                             ZoneDirection::Horizontal,
+                                                             BASE_Z_INDEX,
+                                                             &assets,
+                                                             &handlers);
+        widgets.push(Box::new(hand_zone));
+
+        // TODO: refactor stores: store by name is weird
+
+        // Stores
+        let base_store_position = Vector::new(UI_UNIT, PLAYER_BOARD_FROM_TOP);
+        for (num, store) in gameplay_state.get_board().stores.iter().enumerate() {
+            let shop_zone = CardZone::<CardIcon>::from_container(&store.menu,
+                                                                 base_store_position + Vector::new(0, UI_UNIT * 4.0 * num as f32), // 4U widget height + 1U padding + 1U gap
+                                                                 ZoneDirection::Horizontal,
+                                                                 BASE_Z_INDEX,
+                                                                 &assets,
+                                                                 &handlers);
+            widgets.push(Box::new(shop_zone));
+        }
+
+        // buildings
+        let base_playzone_position = Vector::new(60.0 * UI_UNIT, PLAYER_BOARD_FROM_TOP);
+
+        let build_zone = CardZone::<CardIcon>::from_container(&gameplay_state.get_board().buildings,
+                                                              base_playzone_position,
+                                                              ZoneDirection::Vertical,
+                                                              BASE_Z_INDEX,
+                                                              &assets,
+                                                              &handlers);
+        widgets.push(Box::new(build_zone));
+
+        // kaiju_zone
+        let kaiju_position = base_playzone_position + Vector::new(UI_UNIT * 9.0, 0); // 7U widget height + 1U padding + 1U gap
+        let kaiju_zone = CardZone::<CardIcon>::from_container(&gameplay_state.get_board().kaiju_zone,
+                                                              kaiju_position,
+                                                              ZoneDirection::Vertical,
+                                                              BASE_Z_INDEX,
+                                                              &assets,
+                                                              &handlers);
+        widgets.push(Box::new(kaiju_zone));
+
+        let base_numbers_position = Vector::new(4.0 * UI_UNIT, PLAYER_BOARD_FROM_TOP + 12.0 * UI_UNIT);
+
+        for (num, currency) in Globals::in_game().iter().enumerate() {
+            let value = gameplay_state.get_board().globals.get(*currency);
+            widgets.push(Box::new(Button::new(
+                format!("{:?}\n {}", currency, value),
+                base_numbers_position + Vector::new(UI_UNIT * 5.0, 0) * num as f32,
+                BASE_Z_INDEX,
+                &assets,
+                None,
+            )));
+        }
+
+        Box::new(Self {
+            widgets,
+            window_w,
+            window_h
+        })
+    }
+
+    pub fn handle_io(&mut self, event: Event) -> Option<GameEvent> {
+        match event {
+            // TODO: generalize to arbitrary window sizes
+            Event::MouseMoved(position) => {
+                for w in &mut self.widgets {
+                    w.update_hovered(position);
+                }
+                None
+            }
+            Event::MouseButton(MouseButton::Left, ButtonState::Released) => {
+                self.widgets.iter()
+                    .map(|widg| { widg.maybe_activate() }) // translate to events (maybe all None)
+                    .find(|event| { event.is_some() }) // maybe find first Some
+                    .map(|some_event| { some_event.unwrap() }) // if some, unwrap
+            }
+            _ => None
+        }
+    }
+
+    pub fn update(&mut self) {
+        ()
+    }
+
+    // TODO: make widgets draw to Surface, and arrange the Surfaces
+    pub fn draw(&self, window: &mut Window) -> () {
+        let horizontal_divider = Line::new(
+            Vector::new(0, PLAYER_BOARD_FROM_TOP),
+            Vector::new(self.window_w, PLAYER_BOARD_FROM_TOP),
+        );
+        window.draw(&horizontal_divider, Col(Color::from_rgba(100, 100, 100, 1.0)));
+
+        for widget in &self.widgets {
+            widget.draw(window).unwrap();
+        }
+    }
+}
+
+// This is only a placeholder, to allow us to take() ourselves from &mut Self
+impl Default for BoardDisplay {
+    fn default() -> Self {
+        Self {
+            widgets: Vec::new(),
+            window_w: 0.0,
+            window_h: 0.0
+        }
+    }
+}
+

--- a/src/ui/board_display.rs
+++ b/src/ui/board_display.rs
@@ -29,7 +29,7 @@ impl BoardDisplay {
 
         // Next turn button
         widgets.push(Box::new(Button::new(
-            "End\nturn".to_string(),
+            format!("End turn\ndeck: {}", gameplay_state.get_board().deck.len()),
             Vector::new(UI_UNIT * 7.0, UI_UNIT * 45.0),
             BASE_Z_INDEX,
             &assets,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -63,8 +63,9 @@ impl TakeTurnState {
         let mut widgets = Vec::new();
 
         // Next turn button
+        // TODO: stylize as a card (we can't use CardWidget because we have to pass Card)
         widgets.push(Box::new(Button::new(
-            "End\nturn".to_string(),
+            format!("End turn\ndeck: {}", gameplay_state.get_board().deck.len()),
             Vector::new(UI_UNIT * 7.0, UI_UNIT * 45.0),
             &font,
             Some(GameEvent::EndTurn),
@@ -111,7 +112,7 @@ impl TakeTurnState {
                                                               |idx, card, zone_id| None);
         widgets.push(Box::new(kaiju_zone));
 
-        let base_numbers_position = Vector::new(4.0 * UI_UNIT, PLAYER_BOARD_FROM_TOP + 15.0 * UI_UNIT);
+        let base_numbers_position = Vector::new(4.0 * UI_UNIT, PLAYER_BOARD_FROM_TOP + 11.0 * UI_UNIT);
 
         for (num, currency) in Globals::in_game().iter().enumerate() {
             let value = gameplay_state.get_board().globals.get(*currency);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,108 +2,46 @@
 
 use crate::automaton::*;
 use crate::game_logic::*;
+use std::collections::HashMap;
 use quicksilver::prelude::*;
-use quicksilver::Future;
-use serde::export::fmt::Debug;
 use derivative::*;
 use std::mem::take;
 
 mod widgets;
+mod board_display;
 
 use widgets::*;
 use crate::game_objects::{GameData, Globals, Card, Effect, BoardZone};
-use crate::loading::load_board;
+use board_display::BoardDisplay;
 
 pub const WINDOW_SIZE_W: f32 = 1280.0;
 pub const WINDOW_SIZE_H: f32 = 800.0;
-const PLAYER_BOARD_FROM_TOP: f32 = 300.0;
-const BASE_Z_INDEX: f32 = 1.0; // widgets will be layered starting with this Z
-const FONT_FILE: &'static str = "Teko-Regular.ttf";
 
 // TODO: cache widgets?
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct TakeTurnState {
     gameplay_state: Box<GameplayState>,
-    widgets: Vec<Box<dyn Widget>>,
+    display: Box<BoardDisplay>,
 }
 
 // TODO: load fonts in LoadingState
 impl TakeTurnState {
     pub fn new(gameplay_state: Box<GameplayState>) -> Box<Self> {
-        let assets = gameplay_state.get_assets();
-        let mut widgets = Vec::new();
 
-        // Next turn button
-        widgets.push(Box::new(Button::new(
-            "End\nturn".to_string(),
-            Vector::new(UI_UNIT * 7.0, UI_UNIT * 45.0),
-            BASE_Z_INDEX,
-            &assets,
-            Some(GameEvent::EndTurn),
-        ),
-        ) as Box<dyn Widget>);
+        let mut handler_dict = HashMap::<BoardZone, CardHandler>::new();
 
-        // Hand
-        let hand_zone = CardZone::<CardFull>::from_container(&gameplay_state.get_board().hand,
-                                                             Vector::new(13.0 * UI_UNIT, 35.0 * UI_UNIT),
-                                                             ZoneDirection::Horizontal,
-                                                             BASE_Z_INDEX,
-                                                             &assets,
-                                                             |idx, card, name| Some(GameEvent::CardPicked(idx)));
-        widgets.push(Box::new(hand_zone));
+        handler_dict.insert(BoardZone::Hand, Box::new(|idx, _card, _zone| Some(GameEvent::CardPicked(idx))));
 
-        // TODO: refactor stores: store by name is weird
-
-        // Stores
-        let mut base_store_position = Vector::new(UI_UNIT, PLAYER_BOARD_FROM_TOP);
-        for (num, store) in gameplay_state.get_board().stores.iter().enumerate() {
-            let shop_zone = CardZone::<CardIcon>::from_container(&store.menu,
-                                                                 base_store_position + Vector::new(0, UI_UNIT * 4.0 * num as f32), // 4U widget height + 1U padding + 1U gap
-                                                                 ZoneDirection::Horizontal,
-                                                                 BASE_Z_INDEX,
-                                                                 &assets,
-                                                                 |idx, card, name| Some(GameEvent::CardBought(name, idx)));
-            widgets.push(Box::new(shop_zone));
+        for (_, store) in gameplay_state.get_board().stores.iter().enumerate() {
+            handler_dict.insert(store.menu.zone, Box::new(|idx, _card, zone| Some(GameEvent::CardBought(zone, idx))));
         }
 
-        // buildings
-        let mut base_playzone_position = Vector::new(60.0 * UI_UNIT, PLAYER_BOARD_FROM_TOP);
-
-        let build_zone = CardZone::<CardIcon>::from_container(&gameplay_state.get_board().buildings,
-                                                              base_playzone_position,
-                                                              ZoneDirection::Vertical,
-                                                              BASE_Z_INDEX,
-                                                              &assets,
-                                                              |idx, card, name| None);
-        widgets.push(Box::new(build_zone));
-
-        // kaiju_zone
-        let kaiju_position = base_playzone_position + Vector::new(UI_UNIT * 9.0, 0); // 7U widget height + 1U padding + 1U gap
-        let kaiju_zone = CardZone::<CardIcon>::from_container(&gameplay_state.get_board().kaiju_zone,
-                                                              kaiju_position,
-                                                              ZoneDirection::Vertical,
-                                                              BASE_Z_INDEX,
-                                                              &assets,
-                                                              |idx, card, zone_id| None);
-        widgets.push(Box::new(kaiju_zone));
-
-        let base_numbers_position = Vector::new(4.0 * UI_UNIT, PLAYER_BOARD_FROM_TOP + 12.0 * UI_UNIT);
-
-        for (num, currency) in Globals::in_game().iter().enumerate() {
-            let value = gameplay_state.get_board().globals.get(*currency);
-            widgets.push(Box::new(Button::new(
-                format!("{:?}\n {}", currency, value),
-                base_numbers_position + Vector::new(UI_UNIT * 5.0, 0) * num as f32,
-                BASE_Z_INDEX,
-                &assets,
-                None,
-            )));
-        }
+        let display = BoardDisplay::new(&gameplay_state, handler_dict, WINDOW_SIZE_W, WINDOW_SIZE_H);
 
         Box::new(Self {
             gameplay_state,
-            widgets,
+            display,
         })
     }
 }
@@ -113,7 +51,7 @@ impl Default for TakeTurnState {
     fn default() -> Self {
         Self {
             gameplay_state: Box::new(GameplayState::default()),
-            widgets: Vec::new(),
+            display: Box::new(BoardDisplay::default()),
         }
     }
 }
@@ -121,45 +59,27 @@ impl Default for TakeTurnState {
 impl AutomatonState for TakeTurnState {
     fn event(&mut self, event: GameEvent) -> Box<dyn AutomatonState> {
         match event {
-            // TODO: generalize to arbitrary window sizes
-            GameEvent::IO(Event::MouseMoved(position)) => {
-                for mut w in &mut self.widgets {
-                    w.update_hovered(position);
-                }
-                Box::new(take(self))
+            GameEvent::IO(Event::Key(Key::Escape, ButtonState::Released)) => {
+                Box::new(GameEndedState {})
             }
-            GameEvent::IO(Event::MouseButton(MouseButton::Left, ButtonState::Released)) => {
-                let found = self.widgets.iter()
-                    .map(|widg| { widg.maybe_activate() }) // translate to events (maybe all None)
-                    .find(|event| { event.is_some() }) // maybe find first Some
-                    .map(|some_event| { some_event.unwrap() }); // if some, unwrap
-                match found {
+            GameEvent::IO(io) => {
+                match self.display.handle_io(io) {
                     Some(event) => self.gameplay_state.event(event),
                     None => Box::new(take(self))
                 }
-            }
-            GameEvent::IO(Event::Key(Key::Escape, ButtonState::Released)) => {
-                Box::new(GameEndedState {})
             }
             _ => Box::new(take(self))
         }
     }
 
     fn update(&mut self) -> Box<dyn AutomatonState> {
+        self.display.update();
         Box::new(take(self))
     }
 
     // TODO: make widgets draw to Surface, and arrange the Surfaces
     fn draw(&self, window: &mut Window) -> () {
-        let horizontal_divider = Line::new(
-            Vector::new(0, PLAYER_BOARD_FROM_TOP),
-            Vector::new(WINDOW_SIZE_W, PLAYER_BOARD_FROM_TOP),
-        );
-        window.draw(&horizontal_divider, Col(Color::from_rgba(100, 100, 100, 1.0)));
-
-        for widget in &self.widgets {
-            widget.draw(window).unwrap();
-        }
+        self.display.draw(window)
     }
 }
 
@@ -167,9 +87,10 @@ impl AutomatonState for TakeTurnState {
 #[derivative(Debug)]
 pub struct TargetingState {
     gameplay_state: Box<GameplayState>,
-    widgets: Vec<Box<dyn Widget>>,
+    display: Box<BoardDisplay>,
+
     #[derivative(Debug = "ignore")]
-    font: Font,
+
     acting_card_source: BoardZone,
     acting_card_idx: usize,
     target_zone: BoardZone
@@ -179,15 +100,14 @@ pub struct TargetingState {
 impl TargetingState {
     pub fn new(gameplay_state: Box<GameplayState>, acting_card_source: BoardZone, acting_card_idx: usize, target_zone: BoardZone) -> Box<Self> {
 
-        let font = Font::load(FONT_FILE).wait().expect("Can't load font file");
-        let mut widgets = Vec::new();
-
-        // TODO create widgets
-
+        let mut handler_dict = HashMap::<BoardZone, CardHandler>::new();
+        handler_dict.insert(target_zone, Box::new(move  |idx, card, zone| Some(GameEvent::CardTargeted(acting_card_source, acting_card_idx, zone, idx))));
+    
+        let display = BoardDisplay::new(&gameplay_state, handler_dict, WINDOW_SIZE_W, WINDOW_SIZE_H);
+    
         Box::new(Self {
             gameplay_state,
-            widgets,
-            font,
+            display,
             acting_card_source,
             acting_card_idx,
             target_zone
@@ -219,8 +139,7 @@ impl Default for TargetingState {
     fn default() -> Self {
         Self {
             gameplay_state: Box::new(GameplayState::default()),
-            widgets: Vec::new(),
-            font: Font::load(FONT_FILE).wait().expect("Can't load font file"), // TODO: use preloaded font (or make it optional)
+            display: Box::new(BoardDisplay::default()),
             acting_card_source: BoardZone::None,
             acting_card_idx: 0,
             target_zone: BoardZone::None,
@@ -231,25 +150,31 @@ impl Default for TargetingState {
 impl AutomatonState for TargetingState {
     fn event(&mut self, event: GameEvent) -> Box<dyn AutomatonState> {
         match event {
-            // TODO: handle like in TakeTurnState
-
-            GameEvent::IO(Event::MouseButton(MouseButton::Left, ButtonState::Released)) => {
-                let idx = 0; // TODO find which widget activated
-
-                self.target_selected(Some(idx))  // select card idx
-            }
             GameEvent::IO(Event::Key(Key::Escape, ButtonState::Released)) => {
-                self.target_selected(None)  // Cancel targeting
+                Box::new(GameEndedState {})
+            }
+            GameEvent::IO(Event::MouseButton(MouseButton::Right, ButtonState::Released)) => {
+                // Cancel targetting
+                let event = GameEvent::CardTargeted(BoardZone::None, 0, BoardZone::None, 0);
+                self.gameplay_state.event(event) 
+            }
+            GameEvent::IO(io) => {
+                match self.display.handle_io(io) {
+                    Some(event) => self.gameplay_state.event(event),
+                    None => Box::new(take(self))
+                }
             }
             _ => Box::new(take(self))
         }
     }
 
     fn update(&mut self) -> Box<dyn AutomatonState> {
+        self.display.update();
         Box::new(take(self))
     }
 
+    // TODO: make widgets draw to Surface, and arrange the Surfaces
     fn draw(&self, window: &mut Window) -> () {
-        // TODO draw
+        self.display.draw(window)
     }
 }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -51,7 +51,7 @@ impl<W> CardZone<W> where W: CardWidget {
         }
     }
 
-    pub fn from_container(container: &CardContainer, top_left: Vector, direction: ZoneDirection, font: &Font, on_action: fn (usize, &Card, BoardZone) -> Option<GameEvent>) -> Self {
+    pub fn from_container(container: &CardContainer, top_left: Vector, direction: ZoneDirection, font: &Font, on_action: fn(usize, &Card, BoardZone) -> Option<GameEvent>) -> Self {
         let mut zone = CardZone::new(container.zone, top_left, direction);
 
         for (idx, card) in container.cards.iter().enumerate() {
@@ -134,6 +134,22 @@ impl<W: CardWidget> Widget for CardZone<W> {
     }
 }
 
+fn border_color(hovered: bool, available: bool) -> Color {
+    if hovered {
+        if available {
+            Color::from_rgba(100, 100, 100, 1.0)
+        } else {
+            Color::from_rgba(200, 100, 100, 1.0)
+        }
+    } else {
+        if available {
+            Color::from_rgba(40, 100, 40, 1.0)
+        } else {
+            Color::from_rgba(100, 100, 100, 0.0) // transparent (inactive)
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct CardFull {
     card: Box<Card>,
@@ -176,19 +192,11 @@ impl Widget for CardFull {
     fn draw(&self, window: &mut Window) -> Result<()> {
         let position = self.area.pos;
 
-        if self.hovered {
-            let border_size = self.area.size + Vector::new(PAD_SIZE, PAD_SIZE);
-            let border_position = position - (border_size - self.area.size) * 0.5;
-            let border_area = Rectangle::new(border_position, border_size);
+        let border_size = self.area.size + Vector::new(PAD_SIZE, PAD_SIZE);
+        let border_position = position - (border_size - self.area.size) * 0.5;
+        let border_area = Rectangle::new(border_position, border_size);
 
-            let color = if self.card.available {
-                Color::from_rgba(100, 100, 100, 1.0)
-            } else {
-                Color::from_rgba(200, 100, 100, 1.0)
-            };
-
-            window.draw(&border_area, Col(color));
-        }
+        window.draw(&border_area, Col(border_color(self.hovered, self.card.available)));
 
         let text_rect = self.image.area().translate(position);
         window.draw(&self.area, Col(Color::from_rgba(50, 50, 50, 1.0)));
@@ -243,19 +251,11 @@ impl Widget for CardIcon {
     fn draw(&self, window: &mut Window) -> Result<()> {
         let position = self.area.pos;
 
-        if self.hovered {
-            let border_size = self.area.size + Vector::new(PAD_SIZE, PAD_SIZE);
-            let border_position = position - (border_size - self.area.size) * 0.5;
-            let border_area = Rectangle::new(border_position, border_size);
+        let border_size = self.area.size + Vector::new(PAD_SIZE, PAD_SIZE);
+        let border_position = position - (border_size - self.area.size) * 0.5;
+        let border_area = Rectangle::new(border_position, border_size);
 
-            let color = if self.card.available {
-                Color::from_rgba(100, 100, 100, 1.0)
-            } else {
-                Color::from_rgba(200, 100, 100, 1.0)
-            };
-
-            window.draw(&border_area, Col(color));
-        }
+        window.draw(&border_area, Col(border_color(self.hovered, self.card.available)));
 
         let text_rect = self.image.area().translate(position);
         window.draw(&self.area, Col(Color::from_rgba(50, 50, 50, 1.0)));

--- a/static/cards_expanded.json
+++ b/static/cards_expanded.json
@@ -77,7 +77,6 @@
               "cost": {"count": 2, "currency": "Build"}},
       "evil1": {"name": "Kaiju season",
                 "flavor": "Kaiju appear periodically without provocation",
-                "target_zone": "Kaiju", "target_effect": "Kill",
                 "on_play": [{"effect": "Global", "key": "Evil", "val": 1}, {"effect": "Return"}],
                 "cost": {"count": 0, "currency": "Build"}},
       "evil2": {"name": "Experiments",
@@ -210,7 +209,7 @@
     "egg2": 10
   },
 
-  "build_store": {"type": "Fixed", "items": ["build", "build2", "house", "tank"]},
+  "build_store": {"type": "Fixed", "items": ["build", "build2", "house", "tank", "spawn", "artilery"]},
 
   "military_store": {"type": "Drafted", "size": 5, "from_deck": "build_deck"},
 


### PR DESCRIPTION
The GUI was refactored. Object BoardDisplay (in board_display.rs) is a new widget container with all widgets that show the state of the board (i.e. all of them at the moment). States (TakeTurnState, TargettingState) were much simplified, they just create BoardDisplay and link card event handlers.

With this, card targetting should finally work. Thus it should solve #21 and #22.

It is not yet tested, so it is just a draft. But I want your feedback on this.